### PR TITLE
Updated intro tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ---
 description: >-
   OriginTrail Deep Dive is an all-in-one resource explaining OriginTrail and its
-  utility tokens, TRAC and NEURO, to the general public.
+  utility token, TRAC, to the general public.
 cover: .gitbook/assets/OT_Deep_Dive_Logo_Presentation_12.jpg
 coverY: -479.0700447093889
 layout:


### PR DESCRIPTION
Removed Nuero from intro as being one of the key utility tokens of Origintrail, as this may confuse readers, Nuero is covered more later.